### PR TITLE
Fix vocabulary maze start button light mode

### DIFF
--- a/src/components/vocabulary-maze/ui/MazeBoard.tsx
+++ b/src/components/vocabulary-maze/ui/MazeBoard.tsx
@@ -317,7 +317,7 @@ export const MazeBoard = ({
                 'grid place-items-center',
                 node.type === 'entry' ? 'text-xs' : 'text-4xs sm:text-xs',
                 node.type === 'entry' &&
-                  'bg-ink text-canvas dark:bg-ink-dark dark:text-canvas-dark',
+                  'border border-ink bg-canvas text-ink dark:border-ink-dark dark:bg-ink-dark dark:text-canvas-dark',
                 node.type === 'path' &&
                   'bg-canvas text-ink dark:bg-canvas-dark dark:text-ink-dark',
                 node.type === 'deadEnd' &&


### PR DESCRIPTION
### Motivation
- Hacer visible y coherente el botón de inicio (nodo `entry`) en `/games/vocabulary-maze` cuando la UI está en light mode usando colores de lienzo y un borde, sin alterar el tratamiento en dark mode.

### Description
- Cambiado en `src/components/vocabulary-maze/ui/MazeBoard.tsx` la clase del nodo `entry` reemplazando `bg-ink text-canvas dark:bg-ink-dark dark:text-canvas-dark` por `border border-ink bg-canvas text-ink dark:border-ink-dark dark:bg-ink-dark dark:text-canvas-dark`.

### Testing
- Ejecutado `npm run lint -- src/components/vocabulary-maze/ui/MazeBoard.tsx` y pasó correctamente.
- Ejecutado `npm run build-types` y falló por una advertencia/errores existentes en `tsconfig.json` sobre la opción `baseUrl` (deprecación en TypeScript 6), problema ajeno al cambio.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3db8ffaf2c83289cc093f249c571d3)